### PR TITLE
Check system clock is set correctly before updating

### DIFF
--- a/dont_download.sh
+++ b/dont_download.sh
@@ -399,6 +399,14 @@ initialize() {
     fi
 }
 
+check_system_clock() {
+    if [ "$(date +%Y)" -eq "1970" ];
+    then
+        echo "System clock does not appear to be set correctly: $(date)"
+        exit 1
+    fi
+}
+
 has_patreon_key() {
     if [ ! -f "${UPDATE_ALL_PATREON_KEY_PATH}" ] ; then
         return 1
@@ -826,6 +834,9 @@ countdown() {
 run_update_all() {
 
     initialize
+    echo
+
+    check_system_clock
     echo
 
     sequence


### PR DESCRIPTION
## Issue

If the system time has not been set then update_all.sh is unable to do it's thing

This can happen when the MiSTer has a network connection but was unable to set the time via ntpd.

## Proposed change

Check the system time and bail early with a message if the clock appears to be invalid.


## Steps to reproduce:

Set the system clock back to the epoch
`date -d '@0'`

Try to run the updater:
`/media/fat/Scripts/update_all.sh`

Script fails but it's not immediately obvious what has gone wrong:
```
Downloading
https://github.com/theypsilon/Update_All_MiSTer

Executing 'Update All' script
The All-in-One Updater for MiSTer
Version 1.4

Reading INI file './update_all.ini':
OK.

Sequence:
- Main Distribution: MiSTer-devel
- JTCORES for MiSTer (jtpremium)
- Arcade Offset folder
- BIOS Getter
- MAME Getter
- HBMAME Getter
- Arcade Organizer

Starting in 12 seconds....
 *Press <UP>, To enter the SETTINGS screen.
 *Press <DOWN>, To continu

Start time: Thu 01 Jan 1970 01:52:43 AM BST


################################################################################
#==============================================================================#
################################################################################

Running MiSTer Downloader

START!

Reading file: /media/fat/downloader.ini
Reading 'distribution_mister' db section
Reading 'jtcores' db section
Reading 'arcade_offset_folder' db section
Could not download file from db_url: "https://raw.githubusercontent.com/MiSTer-devel/Distribution_MiSTer/main/db.json.zip"
Could not download file from db_url: "https://raw.githubusercontent.com/jotego/jtpremium/main/jtbindb.json.zip"
Could not download file from db_url: "https://raw.githubusercontent.com/atrac17/Arcade_Offset/db/arcadeoffsetdb.json.zip"
```