### PR TITLE
Makes sure the full INI path is used

### DIFF
--- a/update_all.sh
+++ b/update_all.sh
@@ -33,7 +33,7 @@ else
     ORIGINAL_SCRIPT_PATH="${0}"
 fi
 
-INI_PATH="${ORIGINAL_SCRIPT_PATH%.*}.ini"
+INI_PATH="$(realpath ${ORIGINAL_SCRIPT_PATH%.*}.ini)"
 if [[ -f "${INI_PATH}" ]] ; then
     TMP=$(mktemp)
     dos2unix < "${INI_PATH}" 2> /dev/null | grep -v "^exit" > ${TMP} || true


### PR DESCRIPTION
I noticed when running the script via a SSH console that it will fail to read the INI file and copy the new downloaded script over the old `update_all.sh` (since the path for that is also derived from `$INI_PATH`. Because of the way the INI path is captured, it misses the full/relative path, and since the script is running on `/tmp` it fails (mostly silently).

Just adding `realpath` there seems to fix everything.