### PR TITLE
Fix top 5 dangerous bugs (terminal raw-mode, credential overwrite, firmware cleanup, fd leak, substring check)

### DIFF
--- a/src/update_all/analogue_pocket/firmware_update.py
+++ b/src/update_all/analogue_pocket/firmware_update.py
@@ -56,7 +56,7 @@ def pocket_firmware_update(curl_ssl: str, local_repository: LocalRepository, log
         firmware_name = Path(firmware).name.lower()
         if firmware_name == firmware_info['file'].lower():
             already_on_latest_firmware = True
-            break
+            continue
 
         logger.print(f'Removing old firmware file: {firmware_name}')
         os.remove(firmware)

--- a/src/update_all/arcade_organizer/arcade_organizer.py
+++ b/src/update_all/arcade_organizer/arcade_organizer.py
@@ -703,11 +703,12 @@ class Infrastructure:
 
     def _remove_broken_symlinks(self, directory):
         try:
-            for entry in os.scandir(directory):
-                if entry.is_dir(follow_symlinks=False):
-                    self._remove_broken_symlinks(entry.path)
-                elif entry.is_symlink() and not os.path.exists(entry.path):
-                    os.remove(entry.path)
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    if entry.is_dir(follow_symlinks=False):
+                        self._remove_broken_symlinks(entry.path)
+                    elif entry.is_symlink() and not os.path.exists(entry.path):
+                        os.remove(entry.path)
         except Exception as e:
             self._printer.print("Couldn't clean broken symlinks at " + directory)
             self._printer.print(str(e))

--- a/src/update_all/countdown.py
+++ b/src/update_all/countdown.py
@@ -87,9 +87,16 @@ class CountdownImpl(Countdown):
             time.sleep(1.0 / 60.0)
 
             child_process.terminate()
-            time.sleep(1.0 / 60.0)
-
-            child_process.close()
+            child_process.join(timeout=1.0)
+            try:
+                child_process.close()
+            except ValueError:
+                child_process.kill()
+                child_process.join(timeout=1.0)
+                try:
+                    child_process.close()
+                except ValueError:
+                    pass
             os_specifics.finalize()
             print('', flush=True)
 

--- a/src/update_all/retroaccount.py
+++ b/src/update_all/retroaccount.py
@@ -242,10 +242,12 @@ class RetroAccountService(RetroAccountClient):
         self._logger.bench('RetroAccountService Gateway mister_sync end')
 
         if result == SessionResult.VALID and isinstance(response, dict):
-            new_user_json = response.get('tokens', None)
-            if isinstance(new_user_json, dict) and len(new_user_json) >= 1:
+            tokens = response.get('tokens', None)
+            new_user_json: Optional[dict[str, Any]] = None
+            if isinstance(tokens, dict) and len(tokens) >= 1:
                 self._logger.debug(f'RetroAccountService: New token!')
-                new_user_json['device_id'] = device_id
+                tokens['device_id'] = device_id
+                new_user_json = tokens
 
             benefits = response.get('benefits', {})
             self._logger.debug(f'RetroAccountService: Benefits after mister_sync ', benefits)

--- a/src/update_all/timeline.py
+++ b/src/update_all/timeline.py
@@ -215,7 +215,7 @@ def add_doc_section(doc: list[str], section: dict[str, Any], names_dict: dict[st
 
     for category in categories:
         formatted_category = category['category']
-        if formatted_category in ('system'):
+        if formatted_category == 'system':
             formatted_category = f"{formatted_category.capitalize()} file"
         else:
             formatted_category = formatted_category.capitalize()


### PR DESCRIPTION
## Summary

Five independent, high-confidence bug fixes found while auditing the codebase. Each is a real, demonstrable bug — no refactoring or speculative cleanup. All 164 unit + 85 integration tests still pass.

### 1. `countdown.py` — terminal can be left in raw mode
After `child_process.terminate()`, the code immediately calls `child_process.close()`. `Process.close()` raises `ValueError` if the process hasn't fully exited yet (the read-loop child blocks in `_getch()`, so it relies on terminate to die). When that races, `close()` raises and the subsequent `os_specifics.finalize()` — which restores the TTY — never runs, leaving the user's terminal stuck.

Fix: `join(timeout=1.0)` the child first, wrap `close()` in a `try/except ValueError` with a `kill()` fallback, and ensure `finalize()` always runs.

### 2. `retroaccount.py` — invalid server response can overwrite valid credentials
`_build_mister_sync_transition` did `new_user_json = response.get('tokens', None)` and then conditionally added `device_id` only when the value was a non-empty dict — but unconditionally passed `save_user_json=new_user_json` into the transition. An empty dict or non-dict `tokens` payload would still get written over the valid `user.json`, and on the next sync the missing `device_id`/`refresh_token` would trigger `credentials_were_corrupted` and force the user to re-login.

Fix: only set `new_user_json` (and therefore `save_user_json`) when `tokens` is a non-empty dict.

### 3. `pocket_firmware_update.py` — stale firmware files left on the Pocket SD
The cleanup loop iterates `pocket_firmware*.bin` and removes old ones, but `break`s as soon as it finds the latest. Any stale firmware files that come **after** the latest one in glob order are never removed.

Fix: `continue` instead of `break` so the rest of the directory is still cleaned.

### 4. `arcade_organizer.py` — `os.scandir()` not closed in a recursive function
`_remove_broken_symlinks` calls itself for every subdirectory while holding an open `os.scandir()` iterator (no context manager). Each recursive call leaks a file descriptor until GC. On deep trees this can exhaust the per-process FD limit.

Fix: wrap in `with os.scandir(directory) as entries:`.

### 5. `timeline.py` — substring check instead of equality
`if formatted_category in ('system'):` is missing the trailing comma, so `('system')` is the string `'system'`, not a 1-tuple. Python evaluates this as a substring check (`'sys' in 'system'` is True) rather than equality. Currently masked because no other categories happen to be substrings of `'system'`, but the intent is clearly equality.

Fix: `formatted_category == 'system'`.

## Test plan
- [x] `python3 -m unittest discover -s test/unit` — 164 tests pass
- [x] `python3 -m unittest discover -s test/integration` — 85 tests pass
- [ ] Smoke-test on real MiSTer hardware (countdown abort, sync with stale token response, Pocket firmware update with multiple stale `.bin` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)