### PR TITLE
Fix AZ_DIR=false triggering full rebuild on every run

### DIFF
--- a/src/test/integration/test_arcade_organizer.py
+++ b/src/test/integration/test_arcade_organizer.py
@@ -24,9 +24,9 @@ import unittest
 import zipfile
 from pathlib import Path
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from update_all.arcade_organizer.arcade_organizer import ArcadeOrganizerService
+from update_all.arcade_organizer.arcade_organizer import ArcadeOrganizerService, Infrastructure
 from test.logger_tester import NoLogger
 
 
@@ -706,6 +706,34 @@ class TestArcadeOrganizerIntegration(unittest.TestCase):
             paths_after_second_run,
             "Incremental run should produce identical organization"
         )
+
+    def test_organize___incremental_run_with_az_dir_disabled___does_not_rebuild_from_scratch(self):
+        """Regression test: AZ_DIR=False must not trigger a full rebuild on every run (issue #146).
+
+        A full rebuild and an incremental build produce the same final file set, so comparing
+        paths alone would pass even with the bug. Instead we assert that remove_orgdir_directories
+        is never called on the second run, which is the observable difference between the two paths.
+        """
+        self._create_ini_file(
+            SKIPALTS=False,
+            AZ_DIR=False,
+            CATEGORY_DIR=True
+        )
+
+        config = self.ao_service.make_arcade_organizer_config(
+            self.ini_path,
+            self.base_path,
+            ''
+        )
+
+        success1 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
+        self.assertTrue(success1)
+        self.assertGreater(len(self._get_organized_mra_paths()), 0, "First run should produce files")
+
+        with patch.object(Infrastructure, 'remove_orgdir_directories') as mock_remove:
+            success2 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
+            self.assertTrue(success2)
+            mock_remove.assert_not_called()
 
     def _get_organized_mra_paths(self):
         """Get set of all MRA file paths relative to orgdir."""

--- a/src/update_all/arcade_organizer/arcade_organizer.py
+++ b/src/update_all/arcade_organizer/arcade_organizer.py
@@ -615,6 +615,8 @@ class Infrastructure:
         file_path.unlink()
 
     def check_if_orgdir_directories_are_missing(self):
+        if not self._config['AZ_DIR']:
+            return False
         return not Path(self._config['ORGDIR_09']).is_dir() or \
             not Path(self._config['ORGDIR_AE']).is_dir() or \
             not Path(self._config['ORGDIR_FK']).is_dir() or \


### PR DESCRIPTION
## What

`check_if_orgdir_directories_are_missing()` unconditionally checked for
the alphabetic folders (`_1 0-9`, `_1 A-E`, etc.) even when `AZ_DIR=false`.
Since those folders are never created when alphabetic organization is
disabled, the check always returned true and forced a from-scratch rebuild
on every subsequent run — printing "Some ORGDIR directories are missing."
each time.

## Fix

Early-return `false` from `check_if_orgdir_directories_are_missing()` when
`AZ_DIR` is disabled, matching the same guard already present in
`create_alphabetic()`.

## Test

Added a regression test that runs the organizer twice with `AZ_DIR=false`
and asserts `remove_orgdir_directories` is never called on the second run.
A simple path comparison between runs would pass either way (full and
incremental builds produce identical output), so the mock assertion is the
only reliable way to distinguish the two paths.

Fixes #146
Ref: theypsilon/_arcade-organizer#64 (same bug, previously fixed in the
original bash implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized incremental runs to avoid unnecessary full rebuilds when a specific configuration is disabled.

* **Tests**
  * Added regression test to verify incremental run behavior with disabled configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->