### PR TITLE
[FIX] Simplify `ORGDIR` check for consistent rebuild behavior

### DIFF
--- a/src/test/integration/test_arcade_organizer.py
+++ b/src/test/integration/test_arcade_organizer.py
@@ -707,16 +707,11 @@ class TestArcadeOrganizerIntegration(unittest.TestCase):
             "Incremental run should produce identical organization"
         )
 
-    def test_organize___incremental_run_with_az_dir_disabled___does_not_rebuild_from_scratch(self):
-        """Regression test: AZ_DIR=False must not trigger a full rebuild on every run (issue #146).
-
-        A full rebuild and an incremental build produce the same final file set, so comparing
-        paths alone would pass even with the bug. Instead we assert that remove_orgdir_directories
-        is never called on the second run, which is the observable difference between the two paths.
-        """
+    def test_organize___on_incremental_run___does_not_rebuild_from_scratch(self):
+        """Test that a second run is incremental, not a full rebuild."""
         self._create_ini_file(
             SKIPALTS=False,
-            AZ_DIR=False,
+            AZ_DIR=True,
             CATEGORY_DIR=True
         )
 
@@ -728,12 +723,42 @@ class TestArcadeOrganizerIntegration(unittest.TestCase):
 
         success1 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
         self.assertTrue(success1)
-        self.assertGreater(len(self._get_organized_mra_paths()), 0, "First run should produce files")
 
         with patch.object(Infrastructure, 'remove_orgdir_directories') as mock_remove:
             success2 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
             self.assertTrue(success2)
-            mock_remove.assert_not_called()
+
+            self.assertEqual(mock_remove.call_count, 0, "Second run triggered a full rebuild unexpectedly")
+
+    def test_organize___run_after_deleting_orgdir___rebuilds_from_scratch(self):
+        """Test that deleting _Organized triggers a full rebuild on the next run."""
+        self._create_ini_file(
+            SKIPALTS=False,
+            AZ_DIR=True,
+            CATEGORY_DIR=True
+        )
+
+        config = self.ao_service.make_arcade_organizer_config(
+            self.ini_path,
+            self.base_path,
+            ''
+        )
+
+        success1 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
+        self.assertTrue(success1)
+
+        paths_after_first_run = self._get_organized_mra_paths()
+
+        shutil.rmtree(self.orgdir)
+
+        success2 = self.ao_service.run_arcade_organizer_organize_all_mras(config)
+        self.assertTrue(success2)
+
+        self.assertEqual(
+            paths_after_first_run,
+            self._get_organized_mra_paths(),
+            "Full rebuild after deleting ORGDIR should recreate all organized files"
+        )
 
     def _get_organized_mra_paths(self):
         """Get set of all MRA file paths relative to orgdir."""

--- a/src/update_all/arcade_organizer/arcade_organizer.py
+++ b/src/update_all/arcade_organizer/arcade_organizer.py
@@ -614,15 +614,8 @@ class Infrastructure:
     def remove_file(self, file_path):
         file_path.unlink()
 
-    def check_if_orgdir_directories_are_missing(self):
-        if not self._config['AZ_DIR']:
-            return False
-        return not Path(self._config['ORGDIR_09']).is_dir() or \
-            not Path(self._config['ORGDIR_AE']).is_dir() or \
-            not Path(self._config['ORGDIR_FK']).is_dir() or \
-            not Path(self._config['ORGDIR_LQ']).is_dir() or \
-            not Path(self._config['ORGDIR_RT']).is_dir() or \
-            not Path(self._config['ORGDIR_UZ']).is_dir()
+    def check_if_orgdir_directory_is_missing(self):
+        return not Path(self._config['ORGDIR']).is_dir()
 
     def check_if_names_txt_is_new(self):
         return self._config['ARCADE_ORGANIZER_NAMES_TXT'].is_file() \
@@ -1146,9 +1139,9 @@ class ArcadeOrganizer:
             self._printer.print("Different AO version detected.")
             self._printer.print()
 
-        if self._infra.check_if_orgdir_directories_are_missing():
+        if self._infra.check_if_orgdir_directory_is_missing():
             from_scatch = True
-            self._printer.print("Some ORGDIR directories are missing.")
+            self._printer.print("The ORGDIR directory is missing.")
             self._printer.print()
 
         if not self._infra.text_is_date(last_mra_date):
@@ -1190,7 +1183,7 @@ class ArcadeOrganizer:
             self._infra.remove_orgdir_directories(orgdir_folders_file)
         else:
             self._printer.print("Performing an incremental build.")
-            self._printer.print("NOTE: Remove the Organized folders if you wish to start from scratch.")
+            self._printer.print("NOTE: Remove the Organized folder if you wish to start from scratch.")
             self._infra.remove_all_broken_symlinks()
 
         self._printer.print()


### PR DESCRIPTION
The original heuristic was no longer a real "did the user delete `ORGDIR`?" check, it was an assumption that only worked when `AZ_DIR=True`. With `AZ_DIR=False` those directories are never created, so deleting `ORGDIR` would go undetected and leave the user without an `ORGDIR` entirely.

Instead we should just check whether `ORGDIR` exists. Configuration changes already trigger a rebuild via INI ctime, so this only needs to handle the manual deletion case. This also aligns with the `NOTE: Remove the Organized folders if you wish to start from scratch.` message that is currently displayed to the user during incremental builds.

Fixes #146 (follow-up to merged `AZ_DIR=False` fix)

Manual testing performed:

1. A fresh install creates `ORGDIR` with A-Z subdirectories on first run.
2. Subsequent runs are incremental builds.
3. Removing the `ORGDIR` directory triggers a full build.
4. Disabling A-Z subdirectories triggers an full build via INI change detection.
5. Subsequent runs are incremental builds.
6. Removing the `ORGDIR` directory triggers a full build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuild detection so the app now only performs a full rebuild when the organized output folder is actually missing.
  * Incremental runs now avoid unnecessary cleanup and rebuild steps when existing organized files are still available.
  * If the organized output folder is deleted, the next run correctly rebuilds everything from scratch.
  * Updated the full-build message wording for clearer status feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->