### PR TITLE
Security: Use of shell=True with potentially untrusted input in release_build.py

### DIFF
--- a/.github/release_build.py
+++ b/.github/release_build.py
@@ -34,7 +34,7 @@ if file_has_changed("master", "origin/master", "latest.id"):
 
     subprocess.run(['git', 'push', 'origin', 'master'], check=True)
 
-    subprocess.run('cd build; sha256sum update_all.pyz > update_all.pyz.sha256', shell=True, check=True)
+    subprocess.run(['sha256sum', 'build/update_all.pyz'], stdout=open('build/update_all.pyz.sha256', 'w'), check=True)
     subprocess.run(['zip', 'build/update_all.zip', 'update_all.sh'], check=True)
 
     release_tag = datetime.datetime.now().strftime("UpdateAll_%Y-%m-%d_%H.%M.%S")


### PR DESCRIPTION
## Summary

Security: Use of shell=True with potentially untrusted input in release_build.py

## Problem

**Severity**: `Low` | **File**: `.github/release_build.py:L36`

The `subprocess.run` call uses `shell=True` with a string command. While the current command appears to be hardcoded, using `shell=True` is generally discouraged as it can lead to shell injection vulnerabilities if any part of the command is ever constructed using external input or variables.

## Solution

Avoid using `shell=True`. Instead, pass the command as a list of arguments, e.g., `subprocess.run(['sha256sum', 'build/update_all.pyz'], stdout=open('build/update_all.pyz.sha256', 'w'), check=True)`.

## Changes

- `.github/release_build.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release checksum generation for the update package.
  * Checksum files are now written to a consistent output location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->